### PR TITLE
fix: Workflow path is enumerated, but does not exist any longer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 .venv
 dist
+__pycache__


### PR DESCRIPTION
Dear Daniel,

thanks a stack for conceiving and maintaining this excellent program. When just using it the first time on the repository [cratedb-examples](https://github.com/crate/cratedb-examples), we discovered a minor flaw that appears when accessing GitHub action workflows that are gone, while the API still enumerates them. This patch addresses that problem.

With kind regards,
Andreas.


### Problem Sample
Please visit and review both GHA workflows,
- https://github.com/crate/cratedb-examples/actions/workflows/test-timeseries.yml
- https://github.com/crate/cratedb-examples/actions/workflows/test-singer-meltano.yml

while they are not represented physically within the repository any longer.
- https://github.com/crate/cratedb-examples/tree/main/.github/workflows


### Example Output
While the program would previously croak on non-existing workflows, it now runs to completion, while emitting relevant warning messages to the log output.

```
github-actions-cli --repo crate/cratedb-examples list-workflows
```

```
2024-12-07 02:47:08 sink.fritz.box root[17732] WARNING Workflow not found in repository: crate/cratedb-examples, path: .github/workflows/test-timeseries.yml
2024-12-07 02:47:31 sink.fritz.box root[17732] WARNING Workflow not found in repository: crate/cratedb-examples, path: .github/workflows/test-singer-meltano.yml
.github/workflows/lang-php-amphp.yml - PHP AMPHP
.github/workflows/application-cratedb-toolkit.yml - CrateDB Toolkit
.github/workflows/dataframe-dask.yml - Dask
.github/workflows/lang-npgsql.yml - C# Npgsql
.github/workflows/framework-streamlit.yml - Streamlit
.github/workflows/lang-python-dbapi.yml - Python DB API
.github/workflows/timeseries.yml - Time Series
.github/workflows/application-metabase.yml - Metabase
.github/workflows/framework-flink-kafka-java.yml - Apache Flink: Kafka to JDBC sink (Java)
.github/workflows/framework-gradio.yml - Gradio
.github/workflows/lang-python-sqlalchemy.yml - SQLAlchemy
.github/workflows/framework-dbt.yml - dbt
.github/workflows/lang-ruby.yml - Ruby
.github/workflows/ml-mlflow.yml - MLflow
.github/workflows/application-apache-superset.yml - Apache Superset
.github/workflows/lang-php-pdo.yml - PHP PDO
.github/workflows/ml-langchain.yml - LangChain
.github/workflows/lang-java-maven.yml - Java: JDBC, QA
.github/workflows/dataframe-pandas.yml - pandas
.github/workflows/testing-testcontainers-python.yml - Testcontainers for Python
.github/workflows/ml-automl.yml - AutoML
.github/workflows/testing-native-python.yml - Native Testing with Python
.github/workflows/ml-llamaindex.yml - LlamaIndex
.github/workflows/lang-java-jooq.yml - Java jOOQ
.github/workflows/testing-testcontainers-java.yml - Testcontainers for Java
```

